### PR TITLE
convert coordinates to floats

### DIFF
--- a/src/py_eddy_tracker/dataset/grid.py
+++ b/src/py_eddy_tracker/dataset/grid.py
@@ -424,8 +424,8 @@ class GridDataset(object):
         x_name, y_name = self.coordinates
         if self.is_centered:
             logger.info("Grid center")
-            self.x_c = self.vars[x_name]
-            self.y_c = self.vars[y_name]
+            self.x_c = self.vars[x_name].astype('float64')
+            self.y_c = self.vars[y_name].astype('float64')
 
             self.x_bounds = concatenate((self.x_c, (2 * self.x_c[-1] - self.x_c[-2],)))
             self.y_bounds = concatenate((self.y_c, (2 * self.y_c[-1] - self.y_c[-2],)))
@@ -437,8 +437,8 @@ class GridDataset(object):
             self.y_bounds[-1] -= d_y[-1] / 2
 
         else:
-            self.x_bounds = self.vars[x_name]
-            self.y_bounds = self.vars[y_name]
+            self.x_bounds = self.vars[x_name].astype('float64')
+            self.y_bounds = self.vars[y_name].astype('float64')
 
             if len(self.x_dim) == 1:
                 self.x_c = self.x_bounds.copy()


### PR DESCRIPTION
The following code from example was causing problems:
```python
step=1
g = a.grid_stat(((-180, 180, step), (-80, 90, step)), "amplitude")
```
WIth the traceback:
```python
/mnt/lustre01/pf/a/a270088/PYTHON/EDDY/py-eddy-tracker/src/py_eddy_tracker/dataset/grid.py in setup_coordinates(self)
    444                 self.x_c = self.x_bounds.copy()
    445                 dx2 = (self.x_bounds[1:] - self.x_bounds[:-1]) / 2
--> 446                 self.x_c[:-1] += dx2
    447                 self.x_c[-1] += dx2[-1]
    448                 self.y_c = self.y_bounds.copy()

UFuncTypeError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```
The reason is when the step is 1 (or any other integer), coordinates that are created are also integers (it lon/lat can be divided without reminder). Then when an attempt is made to add floats to them, it causes a problem.

Not sure if it's the right place to convert coordinates to floats, or it should be done earlier. 