### PR TITLE
Resample contours in output form after fitting circles

### DIFF
--- a/src/py_eddy_tracker/poly.py
+++ b/src/py_eddy_tracker/poly.py
@@ -86,7 +86,7 @@ def poly_area_vertice(v):
 @njit(cache=True)
 def poly_area(x, y):
     """
-    Must be call with local coordinates (in m, to get an area in m²).
+    Must be called with local coordinates (in m, to get an area in m²).
 
     :param array x:
     :param array y:


### PR DESCRIPTION
- add parameter presampling_multiplier to evenly over-resample before fitting circles
- fit circles to get eddy parameters (radius, area, etc)
- resample the contours with the output sampling