### PR TITLE
NetCDF Compatibility and requirements.txt update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib
+matplotlib==3.7.1
 opencv-python
 pint
 polygon3


### PR DESCRIPTION
This modification to grid.py allows py-eddy-tracker to intake a netCDF data variable directly, e.g. via xarray. 
## Example:
```
da = ds.isel(time=0).ssh   # xarray data array now holding one time slice
da_netcdf = Dataset('in-mem-file', mode='r', memory=da.to_netcdf())  # This keeps the netCDF variable in memory (no IO to disk!)
g = RegularGridDataset(None, "lon", "lat", centered=True, nc4file= da_netcdf)  
# NOTE: Using 'None' for the .nc file path then requires specifying directly the netCDF variable in memory
#             Still compatible with specifying the .nc file path using the "filename" required input. I this case, variable "nc4file" is ignored
```

Finally, this PR also updates the requirements.txt which has a long-standing error with matplotlib versions after 3.7.1 due to their updated contour algorithm. Across a number of participants at a hackathon, it was determined that v3.7.1 is necessary. Without matplotlib v3.7.1 no errors are raised, but also 0 eddies are ever identified...